### PR TITLE
Use path.sep instead of forward slash

### DIFF
--- a/diveSync.js
+++ b/diveSync.js
@@ -1,4 +1,5 @@
 var fs = require('fs'),
+    OS_PATH_SEP = require('path').sep,
     append = require('append');
 
 // general function
@@ -33,7 +34,7 @@ var diveSync = function(dir, opt, action) {
     list.sort().some(function (file) {
       if (opt.all || file[0] != '.') {
         // full path of that file
-        var path = dir + '/' + file;
+        var path = dir + OS_PATH_SEP + file;
 
         // get the file's stats
         var stat = fs.statSync(path);


### PR DESCRIPTION
Hi,

This is more of a cosmetic improvement.
Currently, if one executes `node test\test.js` the output would look like the following:

```
C:\git-repos\node-diveSync/diveSync.js
C:\git-repos\node-diveSync/node_modules/append/append.js
C:\git-repos\node-diveSync/test/test.js
```

The path separator used (after the directory passed to the function) is always [a forward slash](https://github.com/pvorb/node-diveSync/blob/v0.3.0/diveSync.js#L36) which results in mixing back- and forward slashes on Windows.
With this change the output would look like the following:

```
C:\git-repos\node-diveSync\diveSync.js
C:\git-repos\node-diveSync\node_modules\append\append.js
C:\git-repos\node-diveSync\test\test.js
```

Thanks for having a look at this PR.